### PR TITLE
fix: modified testnet tokens addresses

### DIFF
--- a/apps/web/src/config/constants/tokenLists/pancake-default.tokenlist.json
+++ b/apps/web/src/config/constants/tokenLists/pancake-default.tokenlist.json
@@ -557,23 +557,23 @@
     {
       "name": "Tether USD",
       "symbol": "USDT",
-      "address": "0xD21B917D2f4a4a8E3D12892160BFFd8f4cd72d4F",
+      "address": "0xf7f007dc8Cb507e25e8b7dbDa600c07FdCF9A75B",
       "chainId": 128123,
-      "decimals": 18,
+      "decimals": 6,
       "logoURI": "https://tokens.pancakeswap.finance/images/symbol/usdt.png"
     },
     {
       "name": "USD Coin",
       "symbol": "USDC",
-      "address": "0xa7c9092A5D2C3663B7C5F714dbA806d02d62B58a",
+      "address": "0x4C2AA252BEe766D3399850569713b55178934849",
       "chainId": 128123,
-      "decimals": 18,
+      "decimals": 6,
       "logoURI": "https://tokens.pancakeswap.finance/images/symbol/usdc.png"
     },
     {
       "name": "Wrapped Ether",
       "symbol": "WETH",
-      "address": "0x8DEF68408Bc96553003094180E5C90d9fe5b88C1",
+      "address": "0x86932ff467A7e055d679F7578A0A4F96Be287861",
       "chainId": 128123,
       "decimals": 18,
       "logoURI": "https://raw.githubusercontent.com/IguanaDEX/assets/main/assets/0x8DEF68408Bc96553003094180E5C90d9fe5b88C1.png"

--- a/packages/swap-sdk/src/constants.ts
+++ b/packages/swap-sdk/src/constants.ts
@@ -253,10 +253,10 @@ export const WETH9 = {
   ),
   [ChainId.ETHERLINK_TESTNET]: new ERC20Token(
     ChainId.ETHERLINK_TESTNET,
-    '0x8DEF68408Bc96553003094180E5C90d9fe5b88C1',
+    '0x86932ff467A7e055d679F7578A0A4F96Be287861',
     18,
-    'ETH',
-    'Ether',
+    'WETH',
+    'Wrapped Ether',
     'https://ethereum.org'
   ),
 }

--- a/packages/tokens/src/constants/common.ts
+++ b/packages/tokens/src/constants/common.ts
@@ -344,8 +344,8 @@ export const USDC = {
   ),
   [ChainId.ETHERLINK_TESTNET]: new ERC20Token(
     ChainId.ETHERLINK_TESTNET,
-    '0xa7c9092A5D2C3663B7C5F714dbA806d02d62B58a',
-    18,
+    '0x4C2AA252BEe766D3399850569713b55178934849',
+    6,
     'USDC',
     'USD Coin',
   ),
@@ -406,8 +406,8 @@ export const USDT = {
   [ChainId.LINEA]: new ERC20Token(ChainId.LINEA, '0xA219439258ca9da29E9Cc4cE5596924745e12B93', 6, 'USDT', 'Tether USD'),
   [ChainId.ETHERLINK_TESTNET]: new ERC20Token(
     ChainId.ETHERLINK_TESTNET,
-    '0xD21B917D2f4a4a8E3D12892160BFFd8f4cd72d4F',
-    18,
+    '0xf7f007dc8Cb507e25e8b7dbDa600c07FdCF9A75B',
+    6,
     'USDT',
     'Tether USD',
   ),

--- a/packages/universal-router-sdk/test/fixtures/constants/tokens.ts
+++ b/packages/universal-router-sdk/test/fixtures/constants/tokens.ts
@@ -48,8 +48,8 @@ export const USDT = {
   [ChainId.BASE_TESTNET]: new ERC20Token(ChainId.BASE_TESTNET, zeroAddress, 6, 'USDT'),
   [ChainId.ETHERLINK_TESTNET]: new ERC20Token(
     ChainId.ETHERLINK_TESTNET,
-    '0xD21B917D2f4a4a8E3D12892160BFFd8f4cd72d4F',
-    18,
+    '0xf7f007dc8Cb507e25e8b7dbDa600c07FdCF9A75B',
+    6,
     'USDT',
   ),
 }


### PR DESCRIPTION
Modified the addresses of the testnet tokens USDC, USDT, and WETH because they have been redeployed to match the name, symbol, and decimal on the mainnet. Once this PR is accepted, I will deploy the new pools and add liquidity.