### PR TITLE
Update tzPEPE logo from jpg to png

### DIFF
--- a/apps/web/src/config/constants/tokenLists/pancake-default.tokenlist.json
+++ b/apps/web/src/config/constants/tokenLists/pancake-default.tokenlist.json
@@ -608,7 +608,7 @@
       "address": "0x9121B153bbCF8C23F20eE43b494F08760B91aD64",
       "chainId": 42793,
       "decimals": 2,
-      "logoURI": "https://raw.githubusercontent.com/IguanaDEX/assets/main/assets/0x9121B153bbCF8C23F20eE43b494F08760B91aD64.jpg"
+      "logoURI": "https://raw.githubusercontent.com/IguanaDEX/assets/main/assets/0x9121B153bbCF8C23F20eE43b494F08760B91aD64.png"
     },
     {
       "name": "Midas US Treasury Bill Token",


### PR DESCRIPTION
tzPEPE logo from jpg to png. It is required because the explorer page and components are forcing the .png for the moment.