### PR TITLE
Fix the apple apr matching to properly target pools

### DIFF
--- a/apps/web/src/views/V3Info/components/PoolTable/index.tsx
+++ b/apps/web/src/views/V3Info/components/PoolTable/index.tsx
@@ -68,7 +68,6 @@ const AppleStyledLogo = styled(TokenLogo)<{ size: string }>`
   height: ${({ size }) => size};
   border-radius: ${({ size }) => size};
   box-shadow: 0px 6px 10px rgba(0, 0, 0, 0.075);
-  background-color: #faf9fa;
   color: ${({ theme }) => theme.colors.text};
 `
 
@@ -154,7 +153,11 @@ export default function PoolTable({ poolDatas, maxItems = MAX_ITEMS }: { poolDat
       const matchingFarm = appleFarmData.find((farm) => {
         const token0Match = farm.tokens.some((token) => token.address.toLowerCase() === pool.token0.address)
         const token1Match = farm.tokens.some((token) => token.address.toLowerCase() === pool.token1.address)
-        const tierMatch = farm.name.includes(`${pool.feeTier / 10000}%`) // Match the tier
+        const farmNameParts = farm.name.split(' ')
+        const farmFee = farmNameParts[farmNameParts.length - 1]
+        const poolFee = `${pool.feeTier / 10000}%`
+        const tierMatch = farmFee === poolFee
+
         return token0Match && token1Match && tierMatch
       })
 

--- a/apps/web/src/views/V3Info/views/PoolPage.tsx
+++ b/apps/web/src/views/V3Info/views/PoolPage.tsx
@@ -162,7 +162,11 @@ const PoolPage: React.FC<{ address: string }> = ({ address }) => {
         const matchingFarm = data.find((farm) => {
           const token0Match = farm.tokens.some((token) => token.address.toLowerCase() === poolData?.token0.address)
           const token1Match = farm.tokens.some((token) => token.address.toLowerCase() === poolData?.token1.address)
-          const tierMatch = farm.name.includes(`${poolData!.feeTier / 10000}%`) // Match the tier
+          const farmNameParts = farm.name.split(' ')
+          const farmFee = farmNameParts[farmNameParts.length - 1]
+          const poolFee = `${(poolData?.feeTier ?? 0) / 10000}%`
+          const tierMatch = farmFee === poolFee
+
           return token0Match && token1Match && tierMatch
         })
 


### PR DESCRIPTION
Modifying the code to properly match the pools. Before if the pool was 0.01% or 1%, the matching was targeting both them. Now it should correctly check the whole number.

Also removed the white background around apple logo so it is cleaner when on dark mode.